### PR TITLE
Add exclude_final_dir option for jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ Check for more tails on the Chia CLI here: https://github.com/Chia-Network/chia-
 * `concurrency_start_early_phase` - The phase in which you want to start a plot early. It is recommended to use 4 for this field.
 * `concurrency_start_early_phase_delay` - The maximum number of seconds to wait before a new plot gets kicked off when the start early phase has been detected.
 * `temporary2_destination_sync` - This field will always submit the destination directory as the temporary2 directory. These two directories will be in sync so that they will always be submitted as the same value.
+* `exclude_final_dir` - Whether to skip adding `destination_directory` to harvester for farming

--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ Check for more tails on the Chia CLI here: https://github.com/Chia-Network/chia-
 * `concurrency_start_early_phase` - The phase in which you want to start a plot early. It is recommended to use 4 for this field.
 * `concurrency_start_early_phase_delay` - The maximum number of seconds to wait before a new plot gets kicked off when the start early phase has been detected.
 * `temporary2_destination_sync` - This field will always submit the destination directory as the temporary2 directory. These two directories will be in sync so that they will always be submitted as the same value.
-* `exclude_final_dir` - Whether to skip adding `destination_directory` to harvester for farming
+* `exclude_final_directory` - Whether to skip adding `destination_directory` to harvester for farming

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -131,6 +131,7 @@ jobs:
   # temporary2_destination_sync: This field will always submit the destination directory as the temporary2 directory.
   #                              These two directories will be in sync so that they will always be submitted as the
   #                              same value.
+  # exclude_final_dir: Whether to skip adding `destination_directory` to harvester for farming
   - name: micron
     max_plots: 999
     farmer_public_key:

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -131,7 +131,7 @@ jobs:
   # temporary2_destination_sync: This field will always submit the destination directory as the temporary2 directory.
   #                              These two directories will be in sync so that they will always be submitted as the
   #                              same value.
-  # exclude_final_dir: Whether to skip adding `destination_directory` to harvester for farming
+  # exclude_final_directory: Whether to skip adding `destination_directory` to harvester for farming
   - name: micron
     max_plots: 999
     farmer_public_key:

--- a/plotmanager/library/commands/plots.py
+++ b/plotmanager/library/commands/plots.py
@@ -1,6 +1,6 @@
 def create(size, memory_buffer, temporary_directory, destination_directory, threads, buckets, bitfield,
            chia_location='chia', temporary2_directory=None, farmer_public_key=None, pool_public_key=None,
-           exclude_final_dir=False):
+           exclude_final_directory=False):
     flags = dict(
         k=size,
         b=memory_buffer,
@@ -17,7 +17,7 @@ def create(size, memory_buffer, temporary_directory, destination_directory, thre
         flags['p'] = pool_public_key
     if bitfield is False:
         flags['e'] = ''
-    if exclude_final_dir:
+    if exclude_final_directory:
         flags['x'] = ''
 
     data = [chia_location, 'plots', 'create']

--- a/plotmanager/library/commands/plots.py
+++ b/plotmanager/library/commands/plots.py
@@ -1,5 +1,6 @@
 def create(size, memory_buffer, temporary_directory, destination_directory, threads, buckets, bitfield,
-           chia_location='chia', temporary2_directory=None, farmer_public_key=None, pool_public_key=None):
+           chia_location='chia', temporary2_directory=None, farmer_public_key=None, pool_public_key=None,
+           exclude_final_dir=False):
     flags = dict(
         k=size,
         b=memory_buffer,
@@ -16,6 +17,8 @@ def create(size, memory_buffer, temporary_directory, destination_directory, thre
         flags['p'] = pool_public_key
     if bitfield is False:
         flags['e'] = ''
+    if exclude_final_dir:
+        flags['x'] = ''
 
     data = [chia_location, 'plots', 'create']
     for key, value in flags.items():

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -50,7 +50,7 @@ def load_jobs(config_jobs):
         job.concurrency_start_early_phase = info.get('concurrency_start_early_phase', None)
         job.concurrency_start_early_phase_delay = info.get('concurrency_start_early_phase_delay', None)
         job.temporary2_destination_sync = info.get('temporary2_destination_sync', False)
-        job.exclude_final_dir = info.get('exclude_final_dir', False)
+        job.exclude_final_directory = info.get('exclude_final_directory', False)
 
         job.temporary_directory = info['temporary_directory']
         job.destination_directory = info['destination_directory']
@@ -162,7 +162,7 @@ def start_work(job, chia_location, log_directory):
         threads=job.threads,
         buckets=job.buckets,
         bitfield=job.bitfield,
-        exclude_final_dir=job.exclude_final_dir,
+        exclude_final_directory=job.exclude_final_directory,
     )
     logging.info(f'Starting with plot command: {plot_command}')
 

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -50,6 +50,7 @@ def load_jobs(config_jobs):
         job.concurrency_start_early_phase = info.get('concurrency_start_early_phase', None)
         job.concurrency_start_early_phase_delay = info.get('concurrency_start_early_phase_delay', None)
         job.temporary2_destination_sync = info.get('temporary2_destination_sync', False)
+        job.exclude_final_dir = info.get('exclude_final_dir', False)
 
         job.temporary_directory = info['temporary_directory']
         job.destination_directory = info['destination_directory']
@@ -161,6 +162,7 @@ def start_work(job, chia_location, log_directory):
         threads=job.threads,
         buckets=job.buckets,
         bitfield=job.bitfield,
+        exclude_final_dir=job.exclude_final_dir,
     )
     logging.info(f'Starting with plot command: {plot_command}')
 

--- a/plotmanager/library/utilities/objects.py
+++ b/plotmanager/library/utilities/objects.py
@@ -22,6 +22,7 @@ class Job:
     temporary_directory = None
     temporary2_directory = None
     destination_directory = []
+    exclude_final_directory = None
     size = None
     bitfield = None
     threads = None


### PR DESCRIPTION
Add ability to specify `-x` for `chia plots create`
Useful when you're plotting to a network drive, that has its own harvester running  

![螢幕擷取畫面 2021-04-30 173801](https://user-images.githubusercontent.com/10175554/116678330-c3a16b80-a9db-11eb-9f6d-12ac5c8dc9a7.png)
