### PR TITLE
Skip 'manager.log' when getting log file path 

### DIFF
--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -201,6 +201,8 @@ def get_running_plots(jobs, running_work):
                 continue
             if file.path[-4:] not in ['.log', '.txt']:
                 continue
+            if file.path[-11:] == 'manager.log':
+                continue
             log_file_path = file.path
             logging.info(f'Found log file: {log_file_path}')
         assumed_job = None


### PR DESCRIPTION
The view pipeline would sometimes use 'manager.log' as the log file path for a plot, so sometimes plot info would not update correctly.

This proposed change skips the 'manager.log' file.