### PR TITLE
Fixes typo in start_manager()

### DIFF
--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -18,7 +18,7 @@ from plotmanager.library.utilities.processes import is_windows, get_manager_proc
 
 def start_manager():
     if get_manager_processes():
-        raise ManagerError('Manger is already running.')
+        raise ManagerError('Manager is already running.')
 
     directory = pathlib.Path().resolve()
     stateless_manager_path = os.path.join(directory, 'stateless-manager.py')


### PR DESCRIPTION
I saw that typo and had to do something about it :)

Thanks for this great plot manager! I use it on Linux and Windows. Very easy to use. Hope to make more meaningful contributions in the future.