### PR TITLE
Add support for instrumentation using Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ These are the settings that will be used by the view.
 
 These are different settings in order to send notifications when the plot manager starts and when a plot has been completed.
 
+### instrumentation
+
+Settings for enabling Prometheus to gather metrics.
+
+* `prometheus_enabled` - If enabled, metrics will be gathered and an HTTP server will start up to expose the metrics for Prometheus.
+* `prometheus_port` - HTTP server port.
+
+### List of metrics gathered
+
+- **chia_running_plots**: A [Gauge](https://prometheus.io/docs/concepts/metric_types/#gauge) to see how many plots are currently being created
+- **chia_completed_plots**: A [Counter](https://prometheus.io/docs/concepts/metric_types/#counter) for completed plots
+
 ### progress
 
 * `phase_line_end` - These are the settings that will be used to dictate when a phase ends in the progress bar. It is supposed to reflect the line at which the phase will end so the progress calculations can use that information with the existing log file to calculate a progress percent. 

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -64,6 +64,10 @@ notifications:
   twilio_from_phone: +1234657890
   twilio_to_phone: +1234657890
 
+instrumentation:
+  prometheus_enabled: true
+  prometheus_port: 9093
+
 
 progress:
   # phase_line_end: These are the settings that will be used to dictate when a phase ends in the progress bar. It is

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -65,7 +65,7 @@ notifications:
   twilio_to_phone: +1234657890
 
 instrumentation:
-  prometheus_enabled: true
+  prometheus_enabled: false
   prometheus_port: 9093
 
 

--- a/plotmanager/library/parse/configuration.py
+++ b/plotmanager/library/parse/configuration.py
@@ -113,3 +113,13 @@ def get_config_info():
 
     return chia_location, log_directory, jobs, manager_check_interval, max_concurrent, \
         progress_settings, notification_settings, log_level, view_settings
+
+
+def get_instrumentation_settings():
+    config = _get_config()
+    if 'instrumentation' not in config:
+        raise InvalidYAMLConfigException('Failed to find instrumentation parameter in the YAML.')
+    instrumentation = config['instrumentation']
+    expected_parameters = ['prometheus_enabled']
+    _check_parameters(parameter=instrumentation, expected_parameters=expected_parameters, parameter_type='instrumentation')
+    return instrumentation

--- a/plotmanager/library/utilities/instrumentation.py
+++ b/plotmanager/library/utilities/instrumentation.py
@@ -1,0 +1,36 @@
+import socket
+import logging
+from prometheus_client import Counter, Gauge, start_http_server
+from plotmanager.library.parse.configuration import get_instrumentation_settings
+
+hostname = socket.gethostname()
+settings = get_instrumentation_settings()
+
+
+def _get_metrics():
+    if settings.prometheus_enabled:
+        gauge_plots_running = Gauge('chia_running_plots', 'Number of running plots', ['hostname', 'job'])
+        counter_plots_completed = Counter('chia_completed_plots', 'Total completed plots', ['hostname', 'job'])
+        start_http_server(settings.prometheus_port)
+        return gauge_plots_running, counter_plots_completed
+    else:
+        gauge_plots_running = None
+        counter_plots_completed = None
+        return gauge_plots_running, counter_plots_completed
+
+
+gauge_plots_running, counter_plots_completed = _get_metrics()
+
+
+def set_plots_running(num_plots, job):
+    if settings.prometheus_enabled:
+        gauge_plots_running.labels(hostname=hostname, job=job).set(num_plots)
+    else:
+        logging.debug('Prometheus instrumentation not enabled')
+
+
+def increment_plots_completed(amount, job):
+    if settings.prometheus_enabled:
+        counter_plots_completed.labels(hostname=hostname, job=job).inc(amount)
+    else:
+        logging.debug('Prometheus instrumentation not enabled')

--- a/plotmanager/library/utilities/instrumentation.py
+++ b/plotmanager/library/utilities/instrumentation.py
@@ -8,10 +8,10 @@ settings = get_instrumentation_settings()
 
 
 def _get_metrics():
-    if settings.prometheus_enabled:
+    if settings['prometheus_enabled']:
         gauge_plots_running = Gauge('chia_running_plots', 'Number of running plots', ['hostname', 'queue'])
         counter_plots_completed = Counter('chia_completed_plots', 'Total completed plots', ['hostname', 'queue'])
-        start_http_server(settings.prometheus_port)
+        start_http_server(settings['prometheus_port'])
         return gauge_plots_running, counter_plots_completed
     else:
         gauge_plots_running = None
@@ -23,14 +23,14 @@ gauge_plots_running, counter_plots_completed = _get_metrics()
 
 
 def set_plots_running(num_plots, job):
-    if settings.prometheus_enabled:
+    if settings['prometheus_enabled']:
         gauge_plots_running.labels(hostname=hostname, queue=job).set(num_plots)
     else:
         logging.debug('Prometheus instrumentation not enabled')
 
 
 def increment_plots_completed(amount, job):
-    if settings.prometheus_enabled:
+    if settings['prometheus_enabled']:
         counter_plots_completed.labels(hostname=hostname, queue=job).inc(amount)
     else:
         logging.debug('Prometheus instrumentation not enabled')

--- a/plotmanager/library/utilities/instrumentation.py
+++ b/plotmanager/library/utilities/instrumentation.py
@@ -9,8 +9,8 @@ settings = get_instrumentation_settings()
 
 def _get_metrics():
     if settings.prometheus_enabled:
-        gauge_plots_running = Gauge('chia_running_plots', 'Number of running plots', ['hostname', 'job'])
-        counter_plots_completed = Counter('chia_completed_plots', 'Total completed plots', ['hostname', 'job'])
+        gauge_plots_running = Gauge('chia_running_plots', 'Number of running plots', ['hostname', 'queue'])
+        counter_plots_completed = Counter('chia_completed_plots', 'Total completed plots', ['hostname', 'queue'])
         start_http_server(settings.prometheus_port)
         return gauge_plots_running, counter_plots_completed
     else:
@@ -24,13 +24,13 @@ gauge_plots_running, counter_plots_completed = _get_metrics()
 
 def set_plots_running(num_plots, job):
     if settings.prometheus_enabled:
-        gauge_plots_running.labels(hostname=hostname, job=job).set(num_plots)
+        gauge_plots_running.labels(hostname=hostname, queue=job).set(num_plots)
     else:
         logging.debug('Prometheus instrumentation not enabled')
 
 
 def increment_plots_completed(amount, job):
     if settings.prometheus_enabled:
-        counter_plots_completed.labels(hostname=hostname, job=job).inc(amount)
+        counter_plots_completed.labels(hostname=hostname, queue=job).inc(amount)
     else:
         logging.debug('Prometheus instrumentation not enabled')

--- a/plotmanager/library/utilities/log.py
+++ b/plotmanager/library/utilities/log.py
@@ -5,6 +5,7 @@ import psutil
 import re
 import socket
 
+from plotmanager.library.utilities.instrumentation import increment_plots_completed
 from plotmanager.library.utilities.notifications import send_notifications
 from plotmanager.library.utilities.print import pretty_print_time
 
@@ -191,6 +192,7 @@ def check_log_progress(jobs, running_work, progress_settings, notification_setti
                 job.running_work.remove(pid)
             job.total_running -= 1
             job.total_completed += 1
+            increment_plots_completed(1, job.name)
 
             send_notifications(
                 title='Plot Completed',

--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -230,7 +230,6 @@ def get_running_plots(jobs, running_work):
                 if not job.temporary2_destination_sync and temporary2_directory not in job_temporary2_directory:
                     continue
             logging.info(f'Found job: {job.name}')
-            set_plots_running(job.total_running, job.name)
             assumed_job = job
             break
 
@@ -254,6 +253,7 @@ def get_running_plots(jobs, running_work):
             work.work_id = assumed_job.current_work_id
             assumed_job.current_work_id += 1
             assumed_job.total_running += 1
+            set_plots_running(assumed_job.total_running, assumed_job.name)
             assumed_job.running_work = assumed_job.running_work + [process.pid]
         work.temporary_drive = temporary_drive
         work.temporary2_drive = temporary2_drive

--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from datetime import datetime
 
 from plotmanager.library.utilities.objects import Work
+from plotmanager.library.utilities.instrumentation import set_plots_running
 
 
 def _contains_in_list(string, lst, case_insensitive=False):
@@ -229,6 +230,7 @@ def get_running_plots(jobs, running_work):
                 if not job.temporary2_destination_sync and temporary2_directory not in job_temporary2_directory:
                     continue
             logging.info(f'Found job: {job.name}')
+            set_plots_running(job.total_running, job.name)
             assumed_job = job
             break
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 dateparser==1.0.0
 discord_notify==1.0.0
 playsound==1.2.2
+prometheus-client==0.10.1
 psutil==5.8.0
 python_pushover==0.4
 PyYAML==5.4.1


### PR DESCRIPTION
This adds the framework for gathering metrics using [Prometheus](https://prometheus.io/), plus two metrics to start with.

Once metrics are gathered by Prometheus, they can be visualized using tools like [Grafana](https://grafana.com/).

