### PR TITLE
Add plot process cpu affinity (psutil)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ These are different settings in order to send notifications when the plot manage
 
 ### global
 * `max_concurrent` - The maximum number of plots that your system can run. The manager will not kick off more than this number of plots total over time.
+* `enable_cpu_affinity` - Enable or disable cpu affinity for plot processes. Systems that plot and harvest may see improved harvester or node performance when excluding one or two threads for plotting process.
+* `cpu_affinity` - List of cpu (or threads) to allocate for plot processes. The default example assumes you have a hyper-threaded 4 core CPU (8 logical cores). This config will restrict plot processes to use logical cores 0-5, leaving logical cores 6 and 7 for other processes (6 restricted, 2 free).
 
 ### job
 

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -87,7 +87,7 @@ global:
   #      max_concurrent: The maximum number of plots that your system can run. The manager will not kick off more than
   #                      this number of plots total over time.
   # enable_cpu_affinity: Enable or disable cpu affinity for plot processes. Systems that plot and harvest may see
-  #                      improved harvester or node performance when excluding one or two threads for plotting process
+  #                      improved harvester or node performance when excluding one or two threads for plotting process.
   #        cpu_affinity: List of cpu (or threads) to allocate for plot processes. The default example assumes you have
   #                      a hyper-threaded 4 core CPU (8 logical cores). This config will restrict plot processes to use
   #                      logical cores 0-5, leaving logical cores 6 and 7 for other processes (6 restricted, 2 free).

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -56,7 +56,7 @@ notifications:
   notify_pushover: false
   pushover_user_key: xx
   pushover_api_key: xx
-  
+
   # TWILIO
   notify_twilio: false
   twilio_account_sid: xxxxx
@@ -84,9 +84,16 @@ progress:
 global:
   # These are the settings that will be used globally by the plot manager.
   #
-  # max_concurrent: The maximum number of plots that your system can run. The manager will not kick off more than this
-  #                 number of plots total over time.
+  #      max_concurrent: The maximum number of plots that your system can run. The manager will not kick off more than
+  #                      this number of plots total over time.
+  # enable_cpu_affinity: Enable or disable cpu affinity for plot processes. Systems that plot and harvest may see
+  #                      improved harvester or node performance when excluding one or two threads for plotting process
+  #        cpu_affinity: List of cpu (or threads) to allocate for plot processes. The default example assumes you have
+  #                      a hyper-threaded 4 core CPU (8 logical cores). This config will restrict plot processes to use
+  #                      logical cores 0-5, leaving logical cores 6 and 7 for other processes (6 restricted, 2 free).
   max_concurrent: 10
+  enable_cpu_affinity: false
+  cpu_affinity: [ 0, 1, 2, 3, 4, 5 ]
 
 
 jobs:

--- a/plotmanager/library/parse/configuration.py
+++ b/plotmanager/library/parse/configuration.py
@@ -85,6 +85,16 @@ def _get_view_settings(config):
     return view
 
 
+def _get_cpu_affinity(config):
+    if 'global' not in config:
+        raise InvalidYAMLConfigException('Failed to find global parameter in the YAML.')
+    if 'enable_cpu_affinity' not in config['global']:
+        raise InvalidYAMLConfigException('Failed to find enable_cpu_affinity in the global parameter in the YAML.')
+    if 'cpu_affinity' not in config['global']:
+        raise InvalidYAMLConfigException('Failed to find cpu_affinity in the global parameter in the YAML.')
+    return config['global']['enable_cpu_affinity'], config['global']['cpu_affinity']
+
+
 def _check_parameters(parameter, expected_parameters, parameter_type):
     failed_checks = []
     checks = expected_parameters
@@ -110,6 +120,8 @@ def get_config_info():
     progress_settings = _get_progress_settings(config=config)
     notification_settings = _get_notifications_settings(config=config)
     view_settings = _get_view_settings(config=config)
+    enable_cpu_affinity, cpu_affinity = _get_cpu_affinity(config=config)
 
     return chia_location, log_directory, jobs, manager_check_interval, max_concurrent, \
-        progress_settings, notification_settings, log_level, view_settings
+        progress_settings, notification_settings, log_level, view_settings, \
+        enable_cpu_affinity, cpu_affinity

--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -29,7 +29,9 @@ def start_manager():
     python_file_path = sys.executable
 
     chia_location, log_directory, jobs, manager_check_interval, max_concurrent, progress_settings, \
-        notification_settings, debug_level, view_settings = get_config_info()
+        notification_settings, debug_level, view_settings, \
+        enable_cpu_affinity, cpu_affinity \
+        = get_config_info()
 
     extra_args = []
     if is_windows():
@@ -71,7 +73,9 @@ def stop_manager():
 
 def view():
     chia_location, log_directory, config_jobs, manager_check_interval, max_concurrent, progress_settings, \
-        notification_settings, debug_level, view_settings = get_config_info()
+        notification_settings, debug_level, view_settings, \
+        enable_cpu_affinity, cpu_affinity \
+        = get_config_info()
     view_check_interval = view_settings['check_interval']
     analysis = {'files': {}}
     drives = {'temp': [], 'temp2': [], 'dest': []}
@@ -128,5 +132,7 @@ def view():
 
 def analyze_logs():
     chia_location, log_directory, jobs, manager_check_interval, max_concurrent, progress_settings, \
-       notification_settings, debug_level, view_settings = get_config_info()
+       notification_settings, debug_level, view_settings, \
+       enable_cpu_affinity, cpu_affinity \
+       = get_config_info()
     analyze_log_times(log_directory)

--- a/stateless-manager.py
+++ b/stateless-manager.py
@@ -10,7 +10,8 @@ from plotmanager.library.utilities.processes import get_running_plots
 
 
 chia_location, log_directory, config_jobs, manager_check_interval, max_concurrent, progress_settings, \
-    notification_settings, debug_level, view_settings = get_config_info()
+    notification_settings, debug_level, view_settings, enable_cpu_affinity, cpu_affinity \
+    = get_config_info()
 
 logging.basicConfig(format='%(asctime)s [%(levelname)s]: %(message)s', datefmt='%Y-%m-%d %H:%M:%S', level=debug_level)
 
@@ -23,6 +24,8 @@ logging.info(f'Max Concurrent: {max_concurrent}')
 logging.info(f'Progress Settings: {progress_settings}')
 logging.info(f'Notification Settings: {notification_settings}')
 logging.info(f'View Settings: {view_settings}')
+logging.info(f'Enable CPU Affinity: {enable_cpu_affinity}')
+logging.info(f'CPU Affinity: {cpu_affinity}')
 
 logging.info(f'Loading jobs into objects.')
 jobs = load_jobs(config_jobs)
@@ -63,6 +66,8 @@ while has_active_jobs_and_work(jobs):
         chia_location=chia_location,
         log_directory=log_directory,
         next_log_check=next_log_check,
+        enable_cpu_affinity=enable_cpu_affinity,
+        cpu_affinity=cpu_affinity
     )
 
     logging.info(f'Sleeping for {manager_check_interval} seconds.')


### PR DESCRIPTION
This implementation of [`psutil.Process().cpu_affinity()`](https://psutil.readthedocs.io/en/latest/#psutil.Process.cpu_affinity
) lets the user parameterize a selection of cores/threads specific to their plotting system and bind configured CPU affinity for newly created plotting processes. As specified in the readme and `config.yaml` documentation, this functionality gives the user greater control over their plotting machine's resources.

Some users run full node, wallet, and harvester in addition to plotting processes - I have personally experienced and have seen others run into issues when CPU resource allocation is fully consumed by plotting processes. Even on high-end multi-core CPU's, this may lead to node de-sync and delayed plot scanning (to name a few).

Enabling CPU core/thread restrictions will objectively decrease plotting speed, making this feature optional and disabled by default.

Let me know if there are better formatting conventions and logic simplification.

Any suggestions are welcome.

