### PR TITLE
Fix psutil.AccessDenied on Windows

### DIFF
--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -33,7 +33,7 @@ def get_manager_processes():
                     not _contains_in_list('stateless-manager.py', process.cmdline()):
                 continue
             processes.append(process)
-        except psutil.NoSuchProcess:
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
     return processes
 


### PR DESCRIPTION
As per #67 
It seems on windows, when iterating through processes, AccessDenied would occour on start_full_node.exe when `process.name()`.