### PR TITLE
Bug fix to support multiple temporary directories

### DIFF
--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -77,10 +77,9 @@ def view():
     drives = {'temp': [], 'temp2': [], 'dest': []}
     jobs = load_jobs(config_jobs)
     for job in jobs:
-        drive = job.temporary_directory.split('\\')[0]
-        drives['temp'].append(drive)
         directories = {
             'dest': job.destination_directory,
+            'temp': job.temporary_directory,
             'temp2': job.temporary2_directory,
         }
         for key, directory_list in directories.items():

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -21,14 +21,17 @@ def get_target_directories(job):
     job_offset = job.total_completed + job.total_running
 
     destination_directory = job.destination_directory
+    temporary_directory = job.temporary_directory
     temporary2_directory = job.temporary2_directory
 
     if isinstance(job.destination_directory, list):
         destination_directory = job.destination_directory[job_offset % len(job.destination_directory)]
+    if isinstance(job.temporary_directory, list):
+        temporary_directory = job.temporary_directory[job_offset % len(job.temporary_directory)]
     if isinstance(job.temporary2_directory, list):
         temporary2_directory = job.temporary2_directory[job_offset % len(job.temporary2_directory)]
 
-    return destination_directory, temporary2_directory
+    return destination_directory, temporary_directory, temporary2_directory
 
 
 def load_jobs(config_jobs):
@@ -133,7 +136,7 @@ def start_work(job, chia_location, log_directory):
     now = datetime.now()
     log_file_path = get_log_file_name(log_directory, job, now)
     logging.info(f'Job log file path: {log_file_path}')
-    destination_directory, temporary2_directory = get_target_directories(job)
+    destination_directory, temporary_directory, temporary2_directory = get_target_directories(job)
     logging.info(f'Job destination directory: {destination_directory}')
 
     work = deepcopy(Work())
@@ -155,7 +158,7 @@ def start_work(job, chia_location, log_directory):
         pool_public_key=job.pool_public_key,
         size=job.size,
         memory_buffer=job.memory_buffer,
-        temporary_directory=job.temporary_directory,
+        temporary_directory=temporary_directory,
         temporary2_directory=temporary2_directory,
         destination_directory=destination_directory,
         threads=job.threads,


### PR DESCRIPTION
Bug:
When set temporary_directory as a list like this:
    temporary_directory:
      - /media/temp0/Plots
      - /media/temp1/Plots
The chia command will include -t ['/media/temp0/Plots' '/media/temp1/Plots'], which is an invalid input for chia.

This commit fixes such bug to support multiple temporary directories.
It just copies the mechanisms for destination_directory and  temporary2_directory.
Thus, tasks could utilize input temporary directories one after one.

Tested on Ubuntu 20.04, python 3.8
