### PR TITLE
Fix losing the venv context on Linux

### DIFF
--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -119,7 +119,7 @@ def view():
                 break
             if not has_file:
                 print("Restarting view due to psutil going stale...")
-                system_args = [f'{sys.executable}'] + sys.argv
+                system_args = ['python'] + sys.argv
                 os.execv(sys.executable, system_args)
         except KeyboardInterrupt:
             print("Stopped view.")

--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -119,7 +119,7 @@ def view():
                 break
             if not has_file:
                 print("Restarting view due to psutil going stale...")
-                system_args = [f'"{sys.executable}"'] + sys.argv
+                system_args = [f'{sys.executable}'] + sys.argv
                 os.execv(sys.executable, system_args)
         except KeyboardInterrupt:
             print("Stopped view.")


### PR DESCRIPTION
Possibly fixes #42

It looks like calling the executable as a quoted string is doing something when executed to lose the venv context, which is causing all of the module not found errors.