### PR TITLE
Fix destination filtering for NFS

### DIFF
--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -120,7 +120,7 @@ def get_chia_drives():
 
 def get_system_drives():
     drives = []
-    for disk in psutil.disk_partitions():
+    for disk in psutil.disk_partitions(all=True):
         drive = disk.mountpoint
         if is_windows():
             drive = os.path.splitdrive(drive)[0]


### PR DESCRIPTION
By default, psutil.disk_partitions will not return the NFS mount point, and it will result in drive does not have enough space error. change to True to fix the problem.