### PR TITLE
Include net drives in psutil.disk_partitions()

### DIFF
--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -119,7 +119,7 @@ def get_chia_drives():
 
 def get_system_drives():
     drives = []
-    for disk in psutil.disk_partitions():
+    for disk in psutil.disk_partitions(all=True):
         drive = disk.mountpoint
         if is_windows():
             drive = os.path.splitdrive(drive)[0]


### PR DESCRIPTION
I don't see a way in psutil to include net mounts on Windows. I.e., \foobar\home is mapped to X:, but X: does not appear in the list returned by psutil.disk_partitions() (local drives are).

Solution: To include net drives in the returned list, simply use
```
psutil.disk_partitions(all=True)
```
Works quite well.