### PR TITLE
Multi temp patch

### DIFF
--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -77,9 +77,8 @@ def view():
     drives = {'temp': [], 'temp2': [], 'dest': []}
     jobs = load_jobs(config_jobs)
     for job in jobs:
-        drive = job.temporary_directory.split('\\')[0]
-        drives['temp'].append(drive)
         directories = {
+            'temp': job.temporary_directory,
             'dest': job.destination_directory,
             'temp2': job.temporary2_directory,
         }

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -20,15 +20,18 @@ def has_active_jobs_and_work(jobs):
 def get_target_directories(job):
     job_offset = job.total_completed + job.total_running
 
+    temporary_directory = job.temporary_directory
     destination_directory = job.destination_directory
     temporary2_directory = job.temporary2_directory
 
+    if isinstance(job.temporary_directory, list):
+        temporary_directory = job.temporary_directory[job_offset % len(job.temporary_directory)]
     if isinstance(job.destination_directory, list):
         destination_directory = job.destination_directory[job_offset % len(job.destination_directory)]
     if isinstance(job.temporary2_directory, list):
         temporary2_directory = job.temporary2_directory[job_offset % len(job.temporary2_directory)]
 
-    return destination_directory, temporary2_directory
+    return temporary_directory, destination_directory, temporary2_directory
 
 
 def load_jobs(config_jobs):
@@ -133,8 +136,7 @@ def start_work(job, chia_location, log_directory):
     now = datetime.now()
     log_file_path = get_log_file_name(log_directory, job, now)
     logging.info(f'Job log file path: {log_file_path}')
-    destination_directory, temporary2_directory = get_target_directories(job)
-    logging.info(f'Job destination directory: {destination_directory}')
+    temporary_directory, destination_directory, temporary2_directory = get_target_directories(job)
 
     work = deepcopy(Work())
     work.job = job
@@ -155,7 +157,7 @@ def start_work(job, chia_location, log_directory):
         pool_public_key=job.pool_public_key,
         size=job.size,
         memory_buffer=job.memory_buffer,
-        temporary_directory=job.temporary_directory,
+        temporary_directory=temporary_directory,
         temporary2_directory=temporary2_directory,
         destination_directory=destination_directory,
         threads=job.threads,

--- a/plotmanager/library/utilities/objects.py
+++ b/plotmanager/library/utilities/objects.py
@@ -19,7 +19,7 @@ class Job:
 
     running_work = []
 
-    temporary_directory = None
+    temporary_directory = []
     temporary2_directory = None
     destination_directory = []
     size = None

--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -216,7 +216,7 @@ def get_running_plots(jobs, running_work):
 
         temporary_directory, temporary2_directory, destination_directory = get_plot_directories(commands=process.cmdline())
         for job in jobs:
-            if temporary_directory != job.temporary_directory:
+            if temporary_directory not in job.temporary_directory:
                 continue
             if destination_directory not in job.destination_directory:
                 continue
@@ -235,7 +235,7 @@ def get_running_plots(jobs, running_work):
         plot_id = None
         if log_file_path:
             plot_id = get_plot_id(file_path=log_file_path)
-
+        logging.info(f'Temp file location: {temporary_directory}')            
         temp_file_size = get_temp_size(plot_id=plot_id, temporary_directory=temporary_directory,
                                        temporary2_directory=temporary2_directory)
 


### PR DESCRIPTION
I have slightly modified the library files so that you can use more than one temporary directory within each job. Previously you could only do this for destination directories. It is sometimes very useful to have one job control plotting and staggering on a set of temporary disks. The format in the config.yaml file for using multiple temp directories is exactly the same as it was for multiple destination directories. Following your original logic the temp directories are rotated for each new process. 