### PR TITLE
Specify Chat_ID for Telegram

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -65,6 +65,8 @@ notifications:
   # TELEGRAM
   notify_telegram: false
   telegram_token: xxxxx
+  # [optional] Can be used to specify a different chat to which the notifications are supposed to be sent. Useful for group chats.
+  # chat_id: xxxx
 
   # TWILIO
   notify_twilio: false

--- a/plotmanager/library/utilities/notifications.py
+++ b/plotmanager/library/utilities/notifications.py
@@ -15,7 +15,7 @@ def _send_notifications(title, body, settings):
     
     if settings.get('notify_telegram') is True:
         import telegram_notifier
-        notifier = telegram_notifier.TelegramNotifier(settings.get('telegram_token'), parse_mode="HTML")
+        notifier = telegram_notifier.TelegramNotifier(settings.get('telegram_token'), parse_mode="HTML", chat_id=settings.get('chat_id'))
         notifier.send(body)
 
     if settings.get('notify_ifttt') is True:

--- a/requirements-notification.txt
+++ b/requirements-notification.txt
@@ -2,5 +2,5 @@ discord_notify==1.0.0
 playsound==1.2.2
 prometheus-client==0.10.1
 python_pushover==0.4
-telegram_notifier==0.2
+telegram_notifier==0.3
 requests==2.25.1


### PR DESCRIPTION
Added the ability to specify a chat_id for Telegram notifications. That way you can have the bot send the notification to any channel (that he is a member of), including group chats. Increased telegram_notifier version, because I added the chat_id ability in 0.3 there.