### PR TITLE
disable instrumentation and notification for readonly commands

### DIFF
--- a/plotmanager/library/utilities/commands.py
+++ b/plotmanager/library/utilities/commands.py
@@ -79,8 +79,7 @@ def stop_manager():
 
 def json_output():
     chia_location, log_directory, config_jobs, manager_check_interval, max_concurrent, max_for_phase_1, \
-        minimum_minutes_between_jobs, progress_settings, notification_settings, debug_level, view_settings, \
-        instrumentation_settings = get_config_info()
+        minimum_minutes_between_jobs, progress_settings, _, debug_level, view_settings, _ = get_config_info()
 
     system_drives = get_system_drives()
 
@@ -106,11 +105,9 @@ def json_output():
     running_work = {}
 
     jobs = load_jobs(config_jobs)
-    jobs, running_work = get_running_plots(jobs=jobs, running_work=running_work,
-                                           instrumentation_settings=instrumentation_settings)
+    jobs, running_work = get_running_plots(jobs=jobs, running_work=running_work, instrumentation_settings={})
     check_log_progress(jobs=jobs, running_work=running_work, progress_settings=progress_settings,
-                       notification_settings=notification_settings, view_settings=view_settings,
-                       instrumentation_settings=instrumentation_settings)
+                       notification_settings={}, view_settings=view_settings, instrumentation_settings={})
     print_json(jobs=jobs, running_work=running_work, view_settings=view_settings)
 
     has_file = False
@@ -130,8 +127,7 @@ def json_output():
 
 def view(loop=True):
     chia_location, log_directory, config_jobs, manager_check_interval, max_concurrent, max_for_phase_1, \
-        minimum_minutes_between_jobs, progress_settings, notification_settings, debug_level, view_settings, \
-        instrumentation_settings = get_config_info()
+        minimum_minutes_between_jobs, progress_settings, _, debug_level, view_settings, _ = get_config_info()
     view_check_interval = view_settings['check_interval']
     system_drives = get_system_drives()
     analysis = {'files': {}}
@@ -159,11 +155,9 @@ def view(loop=True):
         try:
             analysis = analyze_log_dates(log_directory=log_directory, analysis=analysis)
             jobs = load_jobs(config_jobs)
-            jobs, running_work = get_running_plots(jobs=jobs, running_work=running_work,
-                                                   instrumentation_settings=instrumentation_settings)
+            jobs, running_work = get_running_plots(jobs=jobs, running_work=running_work, instrumentation_settings={})
             check_log_progress(jobs=jobs, running_work=running_work, progress_settings=progress_settings,
-                               notification_settings=notification_settings, view_settings=view_settings,
-                               instrumentation_settings=instrumentation_settings)
+                               notification_settings={}, view_settings=view_settings, instrumentation_settings={})
             print_view(jobs=jobs, running_work=running_work, analysis=analysis, drives=drives,
                        next_log_check=datetime.now() + timedelta(seconds=view_check_interval),
                        view_settings=view_settings, loop=loop)
@@ -188,7 +182,5 @@ def view(loop=True):
 
 
 def analyze_logs():
-    chia_location, log_directory, config_jobs, manager_check_interval, max_concurrent, max_for_phase_1, \
-        minimum_minutes_between_jobs, progress_settings, notification_settings, debug_level, view_settings, \
-        instrumentation_settings = get_config_info()
+    _, log_directory, _, _, _, _, _, _, _, _, _, _ = get_config_info()
     analyze_log_times(log_directory)


### PR DESCRIPTION
motivation:
view, json, status, analyze_logs commands errored out (prometheus port already used) when I have Prometheus manager.py running. 

suggested fix:
readonly commands ignores notification and instrumentation config values

```
$ python manager.py json
Traceback (most recent call last):
  File "/home/creamsoup/git/Swar-Chia-Plot-Manager/manager.py", line 39, in <module>
    json_output()
  File "/home/creamsoup/git/Swar-Chia-Plot-Manager/plotmanager/library/utilities/commands.py", line 109, in json_output
    jobs, running_work = get_running_plots(jobs=jobs, running_work=running_work,
  File "/home/creamsoup/git/Swar-Chia-Plot-Manager/plotmanager/library/utilities/processes.py", line 254, in get_running_plots
    set_plots_running(total_running_plots=assumed_job.total_running, job_name=assumed_job.name,
  File "/home/creamsoup/git/Swar-Chia-Plot-Manager/plotmanager/library/utilities/instrumentation.py", line 24, in set_plots_running
    _get_metrics(instrumentation_settings=instrumentation_settings)
  File "/home/creamsoup/git/Swar-Chia-Plot-Manager/plotmanager/library/utilities/instrumentation.py", line 19, in _get_metrics
    start_http_server(port)
  File "/home/creamsoup/git/Swar-Chia-Plot-Manager/venv/lib/python3.9/site-packages/prometheus_client/exposition.py", line 149, in start_wsgi_server
    httpd = make_server(addr, port, app, ThreadingWSGIServer, handler_class=_SilentHandler)
  File "/usr/lib/python3.9/wsgiref/simple_server.py", line 154, in make_server
    server = server_class((host, port), handler_class)
  File "/usr/lib/python3.9/socketserver.py", line 452, in __init__
    self.server_bind()
  File "/usr/lib/python3.9/wsgiref/simple_server.py", line 50, in server_bind
    HTTPServer.server_bind(self)
  File "/usr/lib/python3.9/http/server.py", line 138, in server_bind
    socketserver.TCPServer.server_bind(self)
  File "/usr/lib/python3.9/socketserver.py", line 466, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 98] Address already in use
```