### PR TITLE
Added Slack as Notification Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # Custom
 config.yaml
 *.bak
+.vscode/settings.json

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -73,6 +73,10 @@ notifications:
   twilio_from_phone: +1234657890
   twilio_to_phone: +1234657890
 
+  # Slack
+  notify_slack: false
+  slack_webhook_url: https://hooks.slack.com/<your>/<slack>/<webhook>
+
 
 instrumentation:
   # This setting is here in case you wanted to enable instrumentation using Prometheus.

--- a/plotmanager/library/utilities/notifications.py
+++ b/plotmanager/library/utilities/notifications.py
@@ -22,6 +22,14 @@ def _send_notifications(title, body, settings):
         import requests
         requests.post(settings.get('ifttt_webhook_url'), data={'value1': title, 'value2': body})
 
+    if settings.get('notify_slack') is True:
+        import requests
+        data = {
+            'text': title +': ' + body
+        }
+        
+        requests.post(settings.get('slack_webhook_url'), json=data)
+
 
 def send_notifications(title, body, settings):
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 dateparser==1.0.0
 psutil==5.8.0
 PyYAML==5.4.1
-requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dateparser==1.0.0
 psutil==5.8.0
 PyYAML==5.4.1
+requests==2.25.1


### PR DESCRIPTION
Receive notification in slack by consuming the incoming webbook in slack. See [https://api.slack.com/messaging/webhooks](https://api.slack.com/messaging/webhooks)
