### PR TITLE
Update stateless-manager.py

### DIFF
--- a/stateless-manager.py
+++ b/stateless-manager.py
@@ -105,6 +105,10 @@ while has_active_jobs_and_work(jobs):
     )
 
     logging.info(f'Sleeping for {manager_check_interval} seconds.')
-    time.sleep(manager_check_interval)
-
+    try:
+        time.sleep(manager_check_interval)
+    except KeyboardInterrupt as results:
+        logging.info(f'You may have pressed Ctrl + C by mistake. If you need to end it, you can try the stop parameter of manager.py.')
+        pass
+    
 logging.info(f'Manager has exited loop because there are no more active jobs.')


### PR DESCRIPTION
When users use "view" to view a task, they often use "Ctrl + C" to end it, which will cause the "sleep" timer to terminate. I've perfected it.