### PR TITLE
Fix exception encountered when a drive no longer exists

### DIFF
--- a/plotmanager/library/utilities/processes.py
+++ b/plotmanager/library/utilities/processes.py
@@ -133,7 +133,7 @@ def identify_drive(file_path, drives):
     if not file_path:
         return None
     for drive in drives:
-        if drive not in file_path:
+        if drive is None or drive not in file_path:
             continue
         return drive
     return None


### PR DESCRIPTION
If a drive is removed or not present, Chia itself handles the situation fine, but plot manager throws an exception.
This issue also occurs when I pre-populate all possible drives for Chia (i.e. I add D: through Z: drive paths with Chia.)

This small change fixes this error:

```
TypeError: argument 1 must be str, not None
2021-05-26 18:37:10 [ERROR]: Failed to get disk_usage of drive None.
Traceback (most recent call last):
  File "C:\Chia\PlotManager.new\plotmanager\library\utilities\jobs.py", line 173, in monitor_jobs_to_start
    free_space = psutil.disk_usage(drive).free
  File "C:\Users\foo\AppData\Local\Programs\Python\Python39\lib\site-packages\psutil\__init__.py", line 1995, in disk_usage
    return _psplatform.disk_usage(path)
  File "C:\Users\foo\AppData\Local\Programs\Python\Python39\lib\site-packages\psutil\_pswindows.py", line 265, in disk_usage
    total, free = cext.disk_usage(path)
TypeError: argument 1 must be str, not None
```
