### PR TITLE
add chat_id to telegram notifier

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -63,8 +63,11 @@ notifications:
   pushover_api_key: xx
   
   # TELEGRAM
+  # use this URL to find the telegram_chat_id of the telegram group or leave empty to send to everyone
+  # https://api.telegram.org/<telegram_bot_token>/getUpdates
   notify_telegram: false
   telegram_token: xxxxx
+  telegram_chat_id: -1087228824
 
   # TWILIO
   notify_twilio: false

--- a/plotmanager/library/utilities/notifications.py
+++ b/plotmanager/library/utilities/notifications.py
@@ -12,10 +12,14 @@ def _send_notifications(title, body, settings):
         import pushover
         client = pushover.Client(settings.get('pushover_user_key'), api_token=settings.get('pushover_api_key'))
         client.send_message(body, title=title)
-    
+
     if settings.get('notify_telegram') is True:
         import telegram_notifier
-        notifier = telegram_notifier.TelegramNotifier(settings.get('telegram_token'), parse_mode="HTML")
+        notifier = telegram_notifier.TelegramNotifier(
+            token=settings.get('telegram_token'),
+            parse_mode="HTML",
+            chat_id=settings.get('telegram_chat_id')
+        )
         notifier.send(body)
 
     if settings.get('notify_ifttt') is True:


### PR DESCRIPTION
allow config to send telegram notification to a specific chat_id (user or group)