### PR TITLE
Check chia installed tool or with path

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -1,9 +1,10 @@
 # This is a single variable that should contain the location of your chia executable file. This is the blockchain executable.
 #
-# WINDOWS EXAMPLE: C:\Users\Swar\AppData\Local\chia-blockchain\app-1.1.5\resources\app.asar.unpacked\daemon\chia.exe
-#   LINUX EXAMPLE: /usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon/chia
-#  LINUX2 EXAMPLE: /home/swar/chia-blockchain/venv/bin/chia
-#  MAC OS EXAMPLE: /Applications/Chia.app/Contents/Resources/app.asar.unpacked/daemon/chia
+#  WINDOWS EXAMPLE: C:\Users\Swar\AppData\Local\chia-blockchain\app-1.1.5\resources\app.asar.unpacked\daemon\chia.exe
+#    LINUX EXAMPLE: /usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon/chia
+#   LINUX2 EXAMPLE: /home/swar/chia-blockchain/venv/bin/chia
+#   MAC OS EXAMPLE: /Applications/Chia.app/Contents/Resources/app.asar.unpacked/daemon/chia
+# CHIA ON PATH VAR: only 'chia' for LINUX and MAC and 'chia.exe' for WINDOWS
 chia_location:
 
 

--- a/plotmanager/library/utilities/configuration.py
+++ b/plotmanager/library/utilities/configuration.py
@@ -1,10 +1,11 @@
 import os
+from shutil import which
 
 from plotmanager.library.utilities.exceptions import InvalidChiaLocationException, MissingImportError
 
 
 def test_configuration(chia_location, notification_settings, instrumentation_settings):
-    if not os.path.exists(chia_location):
+    if which(chia_location) is None:
         raise InvalidChiaLocationException('The chia_location in your config.yaml does not exist. Please confirm if '
                                            'you have the right version. Also confirm if you have a space after the '
                                            'colon. "chia_location: <DRIVE>" not "chia_location:<DRIVE>"')


### PR DESCRIPTION
In my case, I added chia on PATH variable just be easier for running chia commands.

As Swar-Chia-Plot-Manager checks if chia binary exists by checking with `os.path.exists` we can't just put `chia` on `chia_location`.