### PR TITLE
Adding dynamic progress based starting of plots. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # Custom
 config.yaml
 *.bak
+.idea

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -137,6 +137,9 @@ jobs:
   # size: This refers to the k size of the plot. You would type in something like 32, 33, 34, 35... in here.
   # bitfield: This refers to whether you want to use bitfield or not in your plotting. Typically, you want to keep
   #           this as true.
+  # [OPTIONAL] percent: Use progress percentage to control starting plots, this will aim to space plots 1/max_concurrent
+  #                     spacing apart dynamically. It's recommended to use a short stagger minutes with this as well as
+  #                     max_concurrent_with_start_early >= max_concurrent + 1
   # threads: This is the number of threads that will be assigned to the plotter. Only phase 1 uses more than 1 thread.
   # buckets: The number of buckets to use. The default provided by Chia is 128.
   # memory_buffer: The amount of memory you want to allocate to the process.
@@ -183,6 +186,7 @@ jobs:
     destination_directory: J:\Plots
     size: 32
     bitfield: true
+    percent: false
     threads: 8
     buckets: 128
     memory_buffer: 4000
@@ -216,6 +220,7 @@ jobs:
       - K:\Plots
     size: 32
     bitfield: true
+    percent: false
     threads: 8
     buckets: 128
     memory_buffer: 4000

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -156,7 +156,7 @@ def determine_job_size(k_size):
     if k_size > base_k_size:
         # Why 2.06? Just some quick math from my current plots.
         size *= pow(2.06, k_size-base_k_size)
-        size *= pow(2.06, k_size - base_k_size)
+        size *= pow(2.06, k_size-base_k_size)
     return size
 
 

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -156,6 +156,7 @@ def determine_job_size(k_size):
     if k_size > base_k_size:
         # Why 2.06? Just some quick math from my current plots.
         size *= pow(2.06, k_size-base_k_size)
+        size *= pow(2.06, k_size - base_k_size)
     return size
 
 
@@ -211,11 +212,12 @@ def monitor_jobs_to_start(jobs, running_work, max_concurrent, max_for_phase_1, n
             if running_work[pid].current_phase > 1:
                 continue
             phase_1_count += 1
-        percent = round(percent / job.total_running, 2)
-        minimum_percent = (job.total_running + 1) / 2 / job.max_concurrent * 100
-        if percent < minimum_percent and job.percent:
-            logging.info(f'Minimum percent not met, {percent} vs {minimum_percent}')
-            continue
+        if job.total_running != 0:
+            percent = round(percent / job.total_running, 2)
+            minimum_percent = (job.total_running + 1) / 2 / job.max_concurrent * 100
+            if percent < minimum_percent and job.percent:
+                logging.info(f'Minimum percent not met, {percent} vs {minimum_percent}')
+                continue
         logging.info(f'Total jobs in phase 1: {phase_1_count}')
         if job.max_for_phase_1 and phase_1_count >= job.max_for_phase_1:
             logging.info(f'Job max for phase 1 met, skipping. Max: {job.max_for_phase_1}')

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -120,6 +120,7 @@ def load_jobs(config_jobs):
 
         job.size = info['size']
         job.bitfield = info['bitfield']
+        job.percent = info['percent']
         job.threads = info['threads']
         job.buckets = info['buckets']
         job.memory_buffer = info['memory_buffer']
@@ -204,10 +205,17 @@ def monitor_jobs_to_start(jobs, running_work, max_concurrent, max_for_phase_1, n
                          f'Setting Max: {max_for_phase_1}')
             continue
         phase_1_count = 0
+        percent = 0
         for pid in job.running_work:
+            percent += float(running_work[pid].progress.strip("%"))
             if running_work[pid].current_phase > 1:
                 continue
             phase_1_count += 1
+        percent = round(percent / job.total_running, 2)
+        minimum_percent = (job.total_running + 1) / 2 / job.max_concurrent * 100
+        if percent < minimum_percent and job.percent:
+            logging.info(f'Minimum percent not met, {percent} vs {minimum_percent}')
+            continue
         logging.info(f'Total jobs in phase 1: {phase_1_count}')
         if job.max_for_phase_1 and phase_1_count >= job.max_for_phase_1:
             logging.info(f'Job max for phase 1 met, skipping. Max: {job.max_for_phase_1}')

--- a/plotmanager/library/utilities/objects.py
+++ b/plotmanager/library/utilities/objects.py
@@ -28,6 +28,7 @@ class Job:
     skip_full_destinations = None
     size = None
     bitfield = None
+    percent = None
     threads = None
     buckets = None
     memory_buffer = None


### PR DESCRIPTION
Adding dynamic progress percent based starting. This waits until the average percent is greater than 
(running + 1)/2 * 1/max_concurrent such as for a max concurrent of 8 it would use these values:

<!--StartFragment--><google-sheets-html-origin><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}-->
current running | average %
-- | --
0 | 0.00
1 | 12.50
2 | 18.75
3 | 25.00
4 | 31.25
5 | 37.50
6 | 43.75
7 | 50.00
8 | 56.25
9 | 62.50

<!--EndFragment-->

</google-sheets-html-origin>

such as if there were 7 already running, the average would have to be 50% or greater such as, 
`12.5%, 25%, 37.5%, 50%, 62.5%, 75%, and 87.5 %` as they average out to 50%

This should help in two cases: 
First, when starting up the manager and plots are going faster than the average time fixed stagger minutes waste time.
Second, the user shouldn't have to try and guess/calculate the correct stagger minutes just their max parallel plots. 

This change is completely passive, defaulting to false both in new and old configs without the option. All other config options such as max concurrent, max concurrent with early start, stagger minutes, and max for phase 1 still apply as well. I've documented the option in the config.yaml.default, however, I haven't added anything to the primary README.md yet as I wasn't sure if this would be a default option in the future.

I've been trying this out for about a day so far and plots seem to stagger well. I used a 10-minute minimum stagger so it doesn't delay extra and the average spacing is close to the 48-50 minutes I was using before once steady state is reached. 

Info on not met percentages is also included in the INFO level logs similar to other config options and looks like this:
`2021-06-02 21:39:23 [INFO]: Minimum percent not met, 51.97 vs 56.25`