### PR TITLE
Improved logging to notifications (Discord, Telegram, etc) to also include phase times

### DIFF
--- a/plotmanager/library/utilities/log.py
+++ b/plotmanager/library/utilities/log.py
@@ -5,6 +5,8 @@ import psutil
 import re
 import socket
 
+from datetime import datetime
+
 from plotmanager.library.utilities.instrumentation import increment_plots_completed
 from plotmanager.library.utilities.notifications import send_notifications
 from plotmanager.library.utilities.print import pretty_print_time
@@ -195,9 +197,20 @@ def check_log_progress(jobs, running_work, progress_settings, notification_setti
             job.total_completed += 1
             increment_plots_completed(increment=1, job_name=job.name, instrumentation_settings=instrumentation_settings)
 
+            phase_time_log = []
+            for i in range(1, 5):
+                if phase_times.get(i):
+                    phase_time_log.append(phase_times.get(i))
+            phase_times_log_string = ' / '.join(phase_time_log)
+
+            elapsed_time = (datetime.now() - work.datetime_start)
+            elapsed_time = pretty_print_time(elapsed_time.seconds + elapsed_time.days * 86400)
+
+            plotname = f'plot {work.k_size} {work.datetime_start} {work.plot_id}'
+
             send_notifications(
                 title='Plot Completed',
-                body=f'You completed a plot on {socket.gethostname()}!',
+                body=f'You completed plot "{plotname}" on {socket.gethostname()}! (Phase times: {phase_times_log_string}) Total duration: {elapsed_time}',
                 settings=notification_settings,
             )
             break

--- a/plotmanager/library/utilities/log.py
+++ b/plotmanager/library/utilities/log.py
@@ -206,7 +206,7 @@ def check_log_progress(jobs, running_work, progress_settings, notification_setti
             elapsed_time = (datetime.now() - work.datetime_start)
             elapsed_time = pretty_print_time(elapsed_time.seconds + elapsed_time.days * 86400)
 
-            plotname = f'plot {work.k_size} {work.datetime_start} {work.plot_id}'
+            plotname = f'plot {work.k_size} {work.datetime_start} {work.name}'
 
             send_notifications(
                 title='Plot Completed',

--- a/plotmanager/library/utilities/log.py
+++ b/plotmanager/library/utilities/log.py
@@ -206,7 +206,7 @@ def check_log_progress(jobs, running_work, progress_settings, notification_setti
             elapsed_time = (datetime.now() - work.datetime_start)
             elapsed_time = pretty_print_time(elapsed_time.seconds + elapsed_time.days * 86400)
 
-            plotname = f'plot {work.k_size} {work.datetime_start} {work.name}'
+            plotname = f'plot {work.k_size} {work.datetime_start} {job.name}'
 
             send_notifications(
                 title='Plot Completed',


### PR DESCRIPTION
New logging:

![image](https://user-images.githubusercontent.com/2350015/120628368-e6a0be80-c464-11eb-85dd-72112035dd6e.png)

Ideally I would also like to show the plot size, but for some reason this results in the first `None` in the message above. What I'd also like is to either show the Id or the full file path, but I couldn't manage to do that either.