### PR TITLE
Fill missing work parameters at start_work()

### DIFF
--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -293,6 +293,12 @@ def start_work(job, chia_location, log_directory, drives_free_space):
     work.log_file = log_file_path
     work.datetime_start = now
     work.work_id = job.current_work_id
+    work.k_size = job.size
+
+    drives = list(drives_free_space.keys())
+    work.temporary_drive = identify_drive(file_path=temporary_directory, drives=drives)
+    work.temporary2_drive = identify_drive(file_path=temporary2_directory, drives=drives)
+    work.destination_drive = identify_drive(file_path=destination_directory, drives=drives)
 
     job.current_work_id += 1
 


### PR DESCRIPTION
New work after manager start does not have `destination_drive` parameter filled, thus they are ignored when accounting for free space: https://github.com/swar/Swar-Chia-Plot-Manager/blob/002ac4e70c741cb3fc8f48372c76648710692a65/plotmanager/library/utilities/jobs.py#L183

This causes more work assigned to a particular disk than it should, especially when disk is almost full resulting in overfill.