### PR TITLE
Add support for contract-address to create pool enabled plots

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -124,6 +124,8 @@ jobs:
   # [OPTIONAL] farmer_public_key: Your farmer public key. If none is provided, it will not pass in this variable to the
   #                               chia executable which results in your default keys being used. This is only needed if
   #                               you have chia set up on a machine that does not have your credentials.
+  # [OPTIONAL] pool_contract_address: Your pool contract address, use this instead of pool_public_key to create plots that
+  #                                   are tied to your pool NFT making them eligible for pool farming.
   # [OPTIONAL] pool_public_key: Your pool public key. Same information as the above.
   #
   # temporary_directory: Can be a single value or a list of values. This is where the plotting will take place. If you
@@ -177,6 +179,7 @@ jobs:
   - name: micron
     max_plots: 999
     farmer_public_key:
+    pool_contract_address:
     pool_public_key:
     temporary_directory: Z:\Plotter
     temporary2_directory:
@@ -204,6 +207,7 @@ jobs:
   - name: inland
     max_plots: 999
     farmer_public_key:
+    pool_contract_address:
     pool_public_key:
     temporary_directory:
       - Y:\Plotter1

--- a/plotmanager/library/commands/plots.py
+++ b/plotmanager/library/commands/plots.py
@@ -1,6 +1,6 @@
 def create(size, memory_buffer, temporary_directory, destination_directory, threads, buckets, bitfield,
            chia_location='chia', temporary2_directory=None, farmer_public_key=None, pool_public_key=None,
-           exclude_final_directory=False):
+           exclude_final_directory=False, pool_contract_address=None):
     flags = dict(
         k=size,
         b=memory_buffer,
@@ -13,8 +13,12 @@ def create(size, memory_buffer, temporary_directory, destination_directory, thre
         flags['2'] = temporary2_directory
     if farmer_public_key is not None:
         flags['f'] = farmer_public_key
-    if pool_public_key is not None:
+
+    if pool_contract_address is not None:
+        flags['c'] = pool_contract_address
+    elif pool_public_key is not None:
         flags['p'] = pool_public_key
+
     if bitfield is False:
         flags['e'] = ''
     if exclude_final_directory:

--- a/plotmanager/library/utilities/jobs.py
+++ b/plotmanager/library/utilities/jobs.py
@@ -82,6 +82,7 @@ def load_jobs(config_jobs):
 
         job.farmer_public_key = info.get('farmer_public_key', None)
         job.pool_public_key = info.get('pool_public_key', None)
+        job.pool_contract_address = info.get('pool_contract_address', None)
         job.max_concurrent = info['max_concurrent']
         job.max_concurrent_with_start_early = info['max_concurrent_with_start_early']
 
@@ -314,6 +315,7 @@ def start_work(job, chia_location, log_directory, drives_free_space):
         buckets=job.buckets,
         bitfield=job.bitfield,
         exclude_final_directory=job.exclude_final_directory,
+        pool_contract_address=job.pool_contract_address,
     )
     logging.info(f'Starting with plot command: {plot_command}')
 

--- a/plotmanager/library/utilities/objects.py
+++ b/plotmanager/library/utilities/objects.py
@@ -4,6 +4,7 @@ class Job:
 
     farmer_public_key = None
     pool_public_key = None
+    pool_contract_address = None
 
     total_running = 0
     total_kicked_off = 0


### PR DESCRIPTION
To create plots that can be used by a pool you must configure a `pool_contract_address`.  This parameter will take precedence over a `pool_public_key` if one is provided as the `pool_public_key` is a legacy configuration.

Get your contract address using `chia plotnft show | grep contract`

Source: https://github.com/Chia-Network/chia-blockchain/wiki/Pooling-User-Guide#step-4-add-plots

