### PR TITLE
Adjusted phase lines for MadMax progress calculations

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -93,14 +93,14 @@ progress:
   #                 are the longest phases so they will hold more weight than the others.
   #
   # If you're using "madmax" backend, you should use the following config instead:
-  # phase1_line_end: 20
-  # phase2_line_end: 34
-  # phase3_line_end: 48
-  # phase4_line_end: 53
-  # phase1_weight: 33.4
-  # phase2_weight: 20.43
-  # phase3_weight: 42.29
-  # phase4_weight: 3.88
+  # phase1_line_end: 8
+  # phase2_line_end: 22
+  # phase3_line_end: 36
+  # phase4_line_end: 42
+  # phase1_weight: 48.2
+  # phase2_weight: 21.8
+  # phase3_weight: 25.7
+  # phase4_weight: 4.3
   phase1_line_end: 803
   phase2_line_end: 836
   phase3_line_end: 2476

--- a/plotmanager/library/utilities/log.py
+++ b/plotmanager/library/utilities/log.py
@@ -196,7 +196,7 @@ def get_progress(line_count, progress_settings, backend='chia'):
 
     backend_header_lines = dict(
         chia=0,
-        madmax=11
+        madmax=15
     )
 
     header_lines = backend_header_lines.get(backend)


### PR DESCRIPTION
Hello. I noticed that in windows MadMax stotik's fork actual phase line ends are different in the logs. And what I see is that they should not include backend_header_lines value (which is not 11 but 15 in my case). This produced wrong percentage calculations in the viewer.
As I mentioned header takes 15 lines and Phase 1 end is actually at line 23. Based on the code this header should be taken into account, but something strange happens with the math, and percentage shows correctly only if I manually substract header lines from each phase ends and put these numbers in the config. So 23-15 = 8 etc.
Also phase weights for MadMax are different than for original plotter, I adjusted weights based on my 4 different 12-20 threads PCs logs.