### PR TITLE
fix manager.py view and manager.py status break python 3.12 Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 dateparser==1.0.0
-psutil==5.8.0
+psutil==5.9.6
 PyYAML==5.4.1


### PR DESCRIPTION
psutil up to release 5.9.5 throws this error when running manager.py status and manager.py view with Python 3.12 on Windows.

`
SystemError: argument 1 (impossible<bad format char>)
`

psutil fixed [here](https://github.com/giampaolo/psutil/pull/2270), I tested with the next version up and also the most recent version (5.9.8) and both